### PR TITLE
Change require to require_relative in .gemspec

### DIFF
--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -1,4 +1,4 @@
-require './lib/httpclient/version'
+require_relative './lib/httpclient/version'
 
 Gem::Specification.new { |s|
   s.name = 'httpclient'


### PR DESCRIPTION
I want to use this gem as a local Git dependency and when doing so, I get an error because $LOAD_PATH variable (path from which version file is loaded) is not the root of this repository and therefore I need this gem to contain require_relative, so that the path to required files is resolved relative to this .gemspec file.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>